### PR TITLE
update munit to 1.0.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,8 @@ lazy val munitScalacheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     sharedSettings,
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % "1.18.0",
-      "org.scalameta" %%% "munit" % "1.0.0-M12"
+      "org.scalameta" %%% "munit-diff" % "1.0.0-RC1",
+      "org.scalameta" %%% "munit" % "1.0.0-RC1"
     )
   )
   .jvmSettings(

--- a/tests/shared/src/main/scala/munit/BaseFrameworkSuite.scala
+++ b/tests/shared/src/main/scala/munit/BaseFrameworkSuite.scala
@@ -1,7 +1,7 @@
 package munit
 
+import munit.diff.console.AnsiColors
 import munit.internal.PlatformCompat
-import munit.internal.console.AnsiColors
 import sbt.testing.Event
 import sbt.testing.EventHandler
 import sbt.testing.Logger

--- a/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
+++ b/tests/shared/src/test/scala/munit/CustomPrinterSuite.scala
@@ -1,9 +1,10 @@
 package munit
 
-import org.scalacheck.Prop.forAll
+import munit.diff.Printer
 import munit.internal.console.Printers
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
 
 class CustomPrinterSuite extends FunSuite with ScalaCheckSuite {
 


### PR DESCRIPTION
changes because munit-diff is now an independent artifact: https://github.com/scalameta/munit/pull/756
* add dependency for munit-diff
* adapt imports

closes #11