### PR TITLE
Use `sbt/setup-sbt` action to install sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           distribution: temurin
           java-version: "${{ matrix.java }}"
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt +testsJVM/test
   js:
     runs-on: ubuntu-latest
@@ -28,6 +29,7 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt +testsJS/test
   jsdom:
     runs-on: ubuntu-latest
@@ -38,6 +40,7 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: npm install
       - run: sbt +testsJS/test
   native:
@@ -49,6 +52,7 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt +testsNative/test
   windows:
     runs-on: windows-latest
@@ -59,6 +63,7 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt +testsJVM/test
         shell: bash
   mima:
@@ -70,6 +75,7 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt mimaReportBinaryIssues
   scalafmt:
     runs-on: ubuntu-latest
@@ -91,4 +97,5 @@ jobs:
           distribution: temurin
           java-version: 11
           cache: sbt
+      - uses: sbt/setup-sbt@v1
       - run: sbt scalafixCheckAll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
           cache: sbt
-      - run: git fetch --unshallow
+      - uses: sbt/setup-sbt@v1
       - name: Publish ${{ github.ref }}
         run: |
           sbt ci-release


### PR DESCRIPTION
The ubuntu GHA images are no longer carry `sbt`so installing it is required. 

Replace explicitly calling `git fetch --unshallow` with using `fetch-depth: 0`:
> Set `fetch-depth: 0` to fetch all history for all branches and tags