### PR TITLE
munit: upgrade to v1.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ def scala3 = "3.3.7"
 
 def junitVersion = "4.13.2"
 
-def munitVersion = "1.3.0"
+def munitVersion = "1.3.1"
 
 inThisBuild(
   List(


### PR DESCRIPTION
Bumps munit to match the upstream [v1.3.1 release](https://github.com/scalameta/munit/releases/tag/v1.3.1).

munit released its version 1.3.1 a few days ago https://github.com/scalameta/munit/releases/tag/v1.3.1, I was hopping scala steward to catch this version bump but I'm afraid it might not be running for this repo. Last bump was a manual one https://github.com/scalameta/munit-scalacheck/pull/149.

I'm not sure if the preferred way of suggesting this was through opening an issue. Feel free to close if this will be address as part of another PR.